### PR TITLE
fix获取A站最高清晰度链接bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var acdata = JSON.parse(window.pageInfo.currentVideoInfo.ksPlayJson)
   .adaptationSet.representation;
 console.log(
   "Please copy m3u8 url below(max screen resolution):\n复制以下m3u8链接（最高清晰度）:\n",
-  acdata.pop().url
+  acdata.shift().url
 );
 ```
 


### PR DESCRIPTION
acdata.pop() -> acdata.shift()， 读取一个清晰度的url

我下载时， 列表顺序是 [0]720p, [1]480p, [2]360p.
需要读取第一个才是清晰度最好的.